### PR TITLE
Fix .get method to return None default.

### DIFF
--- a/dotdotdot/config.py
+++ b/dotdotdot/config.py
@@ -51,10 +51,7 @@ def get_fx(self, key, default=None):
     key_exists = hasattr(self, key)
     if key_exists:
         return get_item_fx(self, key)
-    elif default:
-        return default
-    else:
-        raise KeyError
+    return default
 
 
 def get_item_fx(self, key):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,14 +108,13 @@ class TestConfig:
         assert config.test.nest.get('inty') == 1
         assert config.get('test').get('nest').get('inty') == 1
 
-        # test missing key raise KeyError...
-        with pytest.raises(KeyError):
-            x = config.test.nest.get('intys')
+        # test None default
+        assert config.test.nest.get('intys', None) is None
 
-        # but with default value does not
+        # test non-None default
         assert config.test.nest.get('intys', 2) == 2
 
-        # although index lookup still does
+        # test key error
         with pytest.raises(KeyError):
             x = config.test.nest['intys']
 


### PR DESCRIPTION
The .get method throws a KeyError if no default is given for the .get method. This fix will return None instead.